### PR TITLE
Add config for max_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 1.4.0
+  * Added configuration
+
 ## 0.0.1
 
   * Initial release (@mikestephens)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ Simply having the gem in your Gemfile is enough to get you started. Your
 job count will be visible via a Queue Stats tab in the Web UI.
 
 ![Web UI](http://i.imgur.com/eSNVK0O.png)
+
+### Configuration
+
+Add this block to `config/initializers/sidekiq.rb`
+
+```
+Sidekiq::QueueStats.configure do |config|
+  config.max_limit = 50000
+end
+```
+
+#### Max Limit
+
+Iterating through large queues can be resource intensive and take quite a lot of time. This option lets you set an integer to only show queue stats of queues under a pre defined threashold.
+
 ## Dependencies
 
 Depends on Sidekiq >= 2.16.0

--- a/lib/sidekiq-queue-stats.rb
+++ b/lib/sidekiq-queue-stats.rb
@@ -1,1 +1,22 @@
 require "sidekiq/queue_stats"
+require 'sidekiq/queue_stats/configuration'
+
+module Sidekiq
+  module QueueStats
+    class << self
+      attr_accessor :configuration
+    end
+
+    def self.configuration
+      @configuration ||= Configuration.new
+    end
+
+    def self.reset
+      @configuration = Configuration.new
+    end
+
+    def self.configure
+      yield(configuration)
+    end
+  end
+end

--- a/lib/sidekiq/queue_stats.rb
+++ b/lib/sidekiq/queue_stats.rb
@@ -7,6 +7,7 @@ end
 require "sidekiq/api"
 require "sidekiq/queue_stats/version"
 require "sidekiq/queue_stats/web_extension"
+require "sidekiq/queue_stats/configuration"
 
 module Sidekiq
   module QueueStats

--- a/lib/sidekiq/queue_stats/configuration.rb
+++ b/lib/sidekiq/queue_stats/configuration.rb
@@ -1,0 +1,11 @@
+module Sidekiq
+  module QueueStats
+    class Configuration
+      attr_accessor :max_limit
+
+      def initialize
+        @max_limit = nil
+      end
+    end
+  end
+end

--- a/lib/sidekiq/queue_stats/views/queue_stats.erb
+++ b/lib/sidekiq/queue_stats/views/queue_stats.erb
@@ -34,7 +34,7 @@
       <% @workers_count[@selected_queue.name].each do |worker| %>
         <tr>
           <td><%=worker.first%></td>
-          <td><%=worker.last%></td>
+          <td><%=number_with_delimiter(worker.last)%></td>
         </tr>
       <% end %>
     </table>
@@ -47,6 +47,8 @@
       <h4><%= q.capitalize %></h4>
       <% if @workers_count[q].empty? %>
        <div class="alert alert-success">Nothing waiting in queue</div>
+      <% elsif @workers_count[q] == "too_big" %>
+        <div class="alert alert-warning">Queue too large to display. Manually select it to see what is in it.</div>
       <% else %>
        <table class="table table-striped table-bordered table-white">
          <thead>
@@ -58,7 +60,7 @@
          <% @workers_count[q].each do |worker| %>
            <tr>
              <td><%=worker.first%></td>
-             <td><%=worker.last%></td>
+             <td><%=number_with_delimiter(worker.last)%></td>
            </tr>
          <% end %>
        </table>

--- a/lib/sidekiq/queue_stats/web_extension.rb
+++ b/lib/sidekiq/queue_stats/web_extension.rb
@@ -18,9 +18,13 @@ module QueueStats
           else
             queues_list = Sidekiq::Queue.all
             queues_list.each do |q|
-              @workers_count[q.name] = Hash.new(0)
-              q.each do |job|
-                @workers_count[q.name][job.klass] += 1
+              if !Sidekiq::QueueStats.configuration.max_limit.nil? && q.size > Sidekiq::QueueStats.configuration.max_limit
+                @workers_count[q.name] = "too_big"
+              else
+                @workers_count[q.name] = Hash.new(0)
+                q.each do |job|
+                  @workers_count[q.name][job.klass] += 1
+                end
               end
             end
           end


### PR DESCRIPTION
Iterating through large queues can be resource intensive and take quite a lot of time. This option lets you set an integer to only show queue stats of queues under a pre defined threashold.